### PR TITLE
Update Elko Dimmer

### DIFF
--- a/devicetypes/Elko Dimmer
+++ b/devicetypes/Elko Dimmer
@@ -70,7 +70,7 @@ def on() {
 }
 
 def setLevel(value) {
-    zigbee.setLevel(value)
+    zigbee.on() + zigbee.setLevel(value)
 }
 
 def refresh() {


### PR DESCRIPTION
Add support for the dimmer to automatically set desired level from a switched off state, since Elko-dimmers after being switched on always set level to 100 %.